### PR TITLE
Feature/gh 39 minor adjustments

### DIFF
--- a/chronos-frontend/src/app/common/components/tooltip/tooltip.component.html
+++ b/chronos-frontend/src/app/common/components/tooltip/tooltip.component.html
@@ -1,17 +1,26 @@
-<fa-icon [icon]="helpIcon"
-         [ngbTooltip]="template"
-         [ngClass]="{'active': active}"
-         triggers="manual:blur"
-         #t1="ngbTooltip"
-         (click)="toggle(t1)">
-</fa-icon>
+@if (hasContent()) {
+  <fa-icon [icon]="helpIcon"
+          [ngbTooltip]="template"
+          triggers="manual:blur"
+          #t1="ngbTooltip"
+          (click)="toggle(t1)">
+  </fa-icon>
+}
 
-@if (inline && active) {
+@if (inline() && active) {
   <div class="text-secondary-emphasis small">
     <ng-container [ngTemplateOutlet]="template"></ng-container>
   </div>
 }
 
 <ng-template #template>
-  <ng-content></ng-content>
+  @if (text(); as lines) {
+    @for (line of lines; track line) {
+      @if (!!line) {
+        <div>{{ line }}</div>
+      }
+    }
+  } @else {
+    <ng-content></ng-content>
+  }
 </ng-template>

--- a/chronos-frontend/src/app/common/components/tooltip/tooltip.component.scss
+++ b/chronos-frontend/src/app/common/components/tooltip/tooltip.component.scss
@@ -1,8 +1,4 @@
 fa-icon {
-  color: var(--bs-primary-text-emphasis);
+  color: #ffffff;
   cursor: pointer;
-
-  &.active {
-    color: #ffffff;
-  }
 }

--- a/chronos-frontend/src/app/common/components/tooltip/tooltip.component.ts
+++ b/chronos-frontend/src/app/common/components/tooltip/tooltip.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, input, Input} from '@angular/core';
 import {CommonModule} from "@angular/common";
 import {NgbModule, NgbTooltip} from "@ng-bootstrap/ng-bootstrap";
 import {faQuestionCircle} from "@fortawesome/free-solid-svg-icons";
@@ -18,15 +18,20 @@ import {FontAwesomeModule} from "@fortawesome/angular-fontawesome";
 })
 export class TooltipComponent {
 
+  // Icons
   helpIcon = faQuestionCircle;
+
+  // Properties
   active = false;
+  
+  // Inputs
+  text = input<(string | undefined | null)[]>();
+  inline = input(false);
 
-  @Input()
-  inline: boolean = false;
-
+  // Methods
   protected toggle(tooltip: NgbTooltip): void {
     this.active = !this.active;
-    if (this.inline) {
+    if (this.inline()) {
       return;
     }
     if (this.active && tooltip.isOpen()) {
@@ -35,4 +40,12 @@ export class TooltipComponent {
       tooltip.open();
     }
   }
+
+  protected hasContent(): boolean {
+    if (!this.text()) {
+      return true;
+    }
+    return this.text()!.filter(line => !!line).length > 0;
+  }
+
 }

--- a/chronos-frontend/src/app/common/constants/icon.constants.ts
+++ b/chronos-frontend/src/app/common/constants/icon.constants.ts
@@ -13,7 +13,7 @@ export class IconConstants {
   public static readonly ICON_CANCEL = faXmark;
   public static readonly ICON_EDIT = faPen;
   public static readonly ICON_DELETE = faTrash;
-  public static readonly ICON_QUESTION = faCircleQuestion;
+  public static readonly ICON_HELP = faCircleQuestion;
   public static readonly ICON_WARNING = faTriangleExclamation;
   
 }

--- a/chronos-frontend/src/app/common/constants/icon.constants.ts
+++ b/chronos-frontend/src/app/common/constants/icon.constants.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { faCircleQuestion, faPen, faPlus, faSave, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faPen, faPlus, faSave, faTrash, faTriangleExclamation, faXmark } from '@fortawesome/free-solid-svg-icons';
 
 @Injectable({
   providedIn: 'root',
@@ -14,5 +14,6 @@ export class IconConstants {
   public static readonly ICON_EDIT = faPen;
   public static readonly ICON_DELETE = faTrash;
   public static readonly ICON_QUESTION = faCircleQuestion;
+  public static readonly ICON_WARNING = faTriangleExclamation;
   
 }

--- a/chronos-frontend/src/app/common/model/data/data-response-meta-info.dto.ts
+++ b/chronos-frontend/src/app/common/model/data/data-response-meta-info.dto.ts
@@ -10,23 +10,23 @@ export interface DataResponseMetaInfoDTO {
 }
 
 
-export interface SortingDTO {
+interface SortingDTO {
     sortOrder: SortOrder;
     sortBy: string;
 }
 
-export interface PaginationDTO {
+interface PaginationDTO {
     page: number;
     pageSize: number;
 }
 
-export interface FilterDTO {
+interface FilterDTO {
     attribute: string;
     operator: FilterOperator;
     value: string;
 }
 
-export enum FilterOperator {
+enum FilterOperator {
     EQUAL = "EQUAL",
     NOT = "NOT",
     GREATER_THAN = "GREATER_THAN",

--- a/chronos-frontend/src/app/common/model/data/data-response.dto.ts
+++ b/chronos-frontend/src/app/common/model/data/data-response.dto.ts
@@ -1,5 +1,5 @@
-import { EntryDTO } from "./data-element.dto";
-import { DataResponseMetaInfoDTO } from "./data-response.dto copy";
+import { EntryDTO } from "./entry.dto";
+import { DataResponseMetaInfoDTO } from "./data-response-meta-info.dto";
 
 export interface DataResponseDTO {
     meta: DataResponseMetaInfoDTO;

--- a/chronos-frontend/src/app/common/model/data/entry.dto.ts
+++ b/chronos-frontend/src/app/common/model/data/entry.dto.ts
@@ -1,5 +1,5 @@
 export interface EntryDTO {
     elementId: string;
     labels: string[];
-    properties: Record<string, any>;
+    attributes: Record<string, any>;
 }

--- a/chronos-frontend/src/app/common/model/error-response.dto.ts
+++ b/chronos-frontend/src/app/common/model/error-response.dto.ts
@@ -1,0 +1,21 @@
+export type ErrorResponseDTO = {
+    error: {
+        timestamp: string;
+        status: number;
+        errors: ApiErrorDTO[];
+        message: string;
+        path: string;
+    };
+    // other fields are irrelevant
+}
+
+export type ApiErrorDTO = {
+    field: string;
+    constraint: string;
+    message: string;
+    arguments: {
+        min: number;
+        max: number;
+        // TO BE CONTINUED
+    };
+};

--- a/chronos-frontend/src/app/common/util/backend-error.service.ts
+++ b/chronos-frontend/src/app/common/util/backend-error.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { ApiErrorDTO } from '../model/error-response.dto';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BackendErrorService {
+  
+  private readonly ERROR_MAP: Record<string, (key: string, params?: any) => string> = {
+    'org.chronos.schema.error.invalid-length': (key: string, params: any) => `"${key}" may have between ${params.min} and ${params.max} characters`,
+    'org.chronos.schema.error.not-specified': (key: string, params: any) => `"${key}" is not specified`,
+    'org.chronos.schema.error.duplicate-key': (key: string, params: any) => `"${key}" already exists on another element`,
+  }
+
+  public extractErrors(field: string, label: string, apiErrors: ApiErrorDTO[]): string[] {
+    if (!apiErrors) {
+      return [];
+    }
+    const errors = apiErrors.filter(e => e.field === field);
+
+    if (!errors || errors.length === 0) {
+      return [];
+    }
+    return errors.map(e => {
+      const templateFn = this.ERROR_MAP[e.message] || this.ERROR_MAP[e.constraint];
+      if (!!templateFn) {
+        return templateFn(label, e.arguments);
+      }
+      return e.message;
+    });
+  }
+
+}

--- a/chronos-frontend/src/app/common/util/element-attribute.pipe.ts
+++ b/chronos-frontend/src/app/common/util/element-attribute.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { EntryDTO } from '../model/data/data-element.dto';
+import { EntryDTO } from '../model/data/entry.dto';
 
 @Pipe({
   name: 'attribute',
@@ -7,7 +7,7 @@ import { EntryDTO } from '../model/data/data-element.dto';
 export class ElementAttributePipe implements PipeTransform {
 
   transform(value: EntryDTO, ...args: unknown[]): unknown {
-    return value.properties[args[0] as string];
+    return value.attributes[args[0] as string];
   }
 
 }

--- a/chronos-frontend/src/app/common/util/form.service.ts
+++ b/chronos-frontend/src/app/common/util/form.service.ts
@@ -10,6 +10,8 @@ export class FormService {
     required: (key: string) => `"${key}" is required`,
     minlength: (key: string, params: any) => `"${key}" must have at least ${params.requiredLength} characters`,
     maxlength: (key: string, params: any) => `"${key}" may have at most ${params.requiredLength} characters`,
+    min: (key: string, params: any) => `"${key}" must be at least ${params.min}`,
+    max: (key: string, params: any) => `"${key}" may be at most ${params.max}`,
     notUnique: (key: string) => `"${key}" must be unique`,
     pattern: (key: string, params: any) => `"${key}" has an invalid format`,
   }

--- a/chronos-frontend/src/app/modules/admin/clients/admin-data.client.ts
+++ b/chronos-frontend/src/app/modules/admin/clients/admin-data.client.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable, of, take } from 'rxjs';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 
 @Injectable({
   providedIn: 'root',
@@ -12,15 +12,15 @@ export class AdminDataClient {
   
   public saveEntry(entry: EntryDTO): Observable<void> {
     if (entry.elementId) {
-      return this.http.put<void>(`${this.adminApiUrl}/${entry.properties['key']}`, entry).pipe(take(1));
+      return this.http.put<void>(`${this.adminApiUrl}/${entry.attributes['key']}`, entry).pipe(take(1));
     } else {
       return this.http.post<void>(`${this.adminApiUrl}`, entry).pipe(take(1));
     }
   }
 
   public deleteEntry(entry: EntryDTO): Observable<void> {
-    if (entry.properties['key']) {
-      return this.http.delete<void>(`${this.adminApiUrl}/${entry.properties['key']}`).pipe(take(1));
+    if (entry.attributes['key']) {
+      return this.http.delete<void>(`${this.adminApiUrl}/${entry.attributes['key']}`).pipe(take(1));
     }
     return of()
   }

--- a/chronos-frontend/src/app/modules/admin/services/admin-data.service.ts
+++ b/chronos-frontend/src/app/modules/admin/services/admin-data.service.ts
@@ -3,7 +3,7 @@ import { AdminConfirmService } from './admin-confirm.service';
 import { catchError, firstValueFrom, from, Observable, tap } from 'rxjs';
 import { NotificationService } from 'src/app/common/components/notifications/notification.service';
 import { AdminDataClient } from '../clients/admin-data.client';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 
 @Injectable({
   providedIn: 'root',
@@ -16,7 +16,7 @@ export class AdminDataService {
   private notificationService = inject(NotificationService);
 
   public save(entry: EntryDTO): Observable<void> {
-    const entryKey = entry.properties['key'];
+    const entryKey = entry.attributes['key'];
     return this.adminDataClient.saveEntry(entry).pipe(
       catchError((err: any, caught: Observable<void>) => {
         this.notificationService.error(`Error while saving entry "${entryKey}"`);
@@ -29,7 +29,7 @@ export class AdminDataService {
   }
 
   public delete(entry: EntryDTO): Observable<void> {
-    const entryKey = entry.properties['key'];
+    const entryKey = entry.attributes['key'];
     return from(
       this.confirmService.confirm(
         `Confirm Delete ${entryKey}`,

--- a/chronos-frontend/src/app/modules/admin/services/admin-schema.service.ts
+++ b/chronos-frontend/src/app/modules/admin/services/admin-schema.service.ts
@@ -9,6 +9,7 @@ import { AttributeMapper } from 'src/app/common/model/schema/mappers/attribute.m
 import { SchemaResponseDTO } from 'src/app/common/model/schema/schema-response.dto';
 import { SchemaClient } from '../../public/clients/schema.client';
 import { AdminSchemaClient } from '../clients/admin-schema.client';
+import { ErrorResponseDTO } from 'src/app/common/model/error-response.dto';
 
 @Injectable({
   providedIn: 'root',
@@ -56,7 +57,7 @@ export class AdminSchemaService {
     return this.adminSchemaClient.saveType(type).pipe(
       catchError((err: any, caught: Observable<void>) => {
         this.notificationService.error(`Error while saving type "${type.key}"`);
-        throw new Error("Type not saved");
+        throw err as ErrorResponseDTO;
       }),
       tap(() => {
         this.notificationService.success(`Type "${type.key}" saved successfully`);

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.html
@@ -21,12 +21,20 @@
     <fa-icon [icon]="cancelIcon"></fa-icon>
     Cancel
   </button>
-  <button class="btn btn-outline-success"
-          (click)="save()"
-          [disabled]="!form().valid">
-    <fa-icon [icon]="saveIcon"></fa-icon>
-    Save
-  </button>
+  <div class="btn-group" role="group">
+    <button class="btn btn-outline-success"
+            (click)="save(false)"
+            [disabled]="!form().valid">
+      <fa-icon [icon]="saveIcon"></fa-icon>
+      Save
+    </button>
+    <button class="btn btn-success"
+            (click)="save(true)"
+            [disabled]="!form().valid">
+      <fa-icon [icon]="saveIcon"></fa-icon>
+      Save & return
+    </button>
+  </div>
 </div>
 
 @if (schema.isLoading()) {

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.html
@@ -74,19 +74,6 @@
       </form>
 
 
-      <!-- Tooltip Content -->
-      <ng-template #tipContent let-attr="attr">
-        @if(attr.explanation) {
-          <div>{{ attr.explanation }}</div>
-        }
-        @if(attr.examples) {
-          <div>
-            Examples: {{ attr.examples }}
-          </div>
-        }
-      </ng-template>
-      
-
       @if(selectedType(); as type) {
         <form [formGroup]="form()">
           <h2 id="entry-attributes">Attributes</h2>
@@ -103,14 +90,8 @@
               <div class="row mt-2">
                   <label class="col-sm-4 col-form-label capitalize" [attr.for]="attr.key">
                       {{ attr.key }}{{ attr.isMandatory ? ' *' : '' }}:
-                      @if(attr.explanation || attr.examples) {
-                        <fa-icon [icon]="questionIcon"
-		                             [ngbTooltip]="tipContent"
-                                 class="pointer"
-                                 triggers="manual"
-		                             #tooltip="ngbTooltip"
-                                 (click)="toggleTooltip(tooltip, attr)"></fa-icon>
-                      }
+                      <chronos-tooltip [text]="[attr.explanation, attr.examples]">
+                      </chronos-tooltip>
                   </label>
                   <div class="col-sm-8">
                       <chronos-dynamic-input [attribute]="attr"
@@ -133,14 +114,8 @@
               <div class="row mt-2">
                   <label class="col-sm-4 col-form-label capitalize" [attr.for]="attr.key">
                       {{ attr.key }}{{ attr.isMandatory ? ' *' : '' }}:
-                      @if(attr.explanation || attr.examples) {
-                        <fa-icon [icon]="questionIcon"
-		                             [ngbTooltip]="tipContent"
-                                 class="pointer"
-                                 triggers="manual"
-		                             #tooltip="ngbTooltip"
-                                 (click)="toggleTooltip(tooltip, attr)"></fa-icon>
-                      }
+                      <chronos-tooltip [text]="[attr.explanation, attr.examples]">
+                      </chronos-tooltip>
                   </label>
                   <div class="col-sm-8">
                       <chronos-dynamic-input [attribute]="attr"

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
@@ -9,10 +9,9 @@ import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { DynamicInputComponent } from './dynamic-input/dynamic-input.component';
 import { EntryAttributeFormService } from './entry-attribute-form.service';
-import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { AttributeAO } from 'src/app/common/model/schema/admin/attribute.ao';
 import { AdminDataService } from '../../../services/admin-data.service';
 import { firstValueFrom } from 'rxjs';
+import { TooltipComponent } from 'src/app/common/components/tooltip/tooltip.component';
 
 @Component({
   selector: 'chronos-edit-entry',
@@ -20,7 +19,7 @@ import { firstValueFrom } from 'rxjs';
     FontAwesomeModule,
     ReactiveFormsModule,
     DynamicInputComponent,
-    NgbTooltip
+    TooltipComponent
   ],
   templateUrl: './edit-entry.component.html',
   styleUrl: './edit-entry.component.scss',
@@ -132,13 +131,5 @@ export class EditEntryComponent {
     this.entry.update(e => ({ ...e, labels: [this.typeForm?.getRawValue().type] }));
     this.entry.update(e => ({ ...e, properties: { ...e.properties, ...properties } }));
   }
-
-  protected toggleTooltip(tooltip: NgbTooltip, attr: AttributeAO) {
-		if (tooltip.isOpen()) {
-			tooltip.close();
-		} else {
-			tooltip.open({attr});
-		}
-	}
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
@@ -91,12 +91,14 @@ export class EditEntryComponent {
   }
 
   // Methods
-  protected save() {
+  protected save(returnAfterSave: boolean = false) {
     this.updateType();
     console.log('Saving entry', this.entry());
     firstValueFrom(this.adminDataService.save(this.entry())).then(
       () => {
-        this.back();
+        if (returnAfterSave) {
+          this.back();
+        }
       },
       (err) => {
         // Nothing todo

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
@@ -37,7 +37,7 @@ export class EditEntryComponent {
   protected cancelIcon = IconConstants.ICON_CANCEL;
   protected saveIcon = IconConstants.ICON_SAVE;
   protected deleteIcon = IconConstants.ICON_DELETE;
-  protected questionIcon = IconConstants.ICON_QUESTION;
+  protected questionIcon = IconConstants.ICON_HELP;
 
   // Dependencies
   private route: ActivatedRoute = inject(ActivatedRoute);

--- a/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/data/edit-entry/edit-entry.component.ts
@@ -5,7 +5,7 @@ import { FaIconLibrary, FontAwesomeModule } from '@fortawesome/angular-fontaweso
 import { IconConstants } from 'src/app/common/constants/icon.constants';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AdminSchemaService } from '../../../services/admin-schema.service';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { DynamicInputComponent } from './dynamic-input/dynamic-input.component';
 import { EntryAttributeFormService } from './entry-attribute-form.service';
@@ -30,7 +30,7 @@ export class EditEntryComponent {
   protected entry: WritableSignal<EntryDTO> = signal({
     elementId: '',
     labels: [],
-    properties: {}
+    attributes: {}
   });
 
   // Icons
@@ -86,7 +86,7 @@ export class EditEntryComponent {
 
     effect(() => {
       const entry = this.entry();
-      this.form().patchValue(entry.properties);
+      this.form().patchValue(entry.attributes);
     });
   }
 
@@ -129,9 +129,9 @@ export class EditEntryComponent {
   }
 
   protected updateType(): void {
-    const properties = this.form().getRawValue();
+    const attributes = this.form().getRawValue();
     this.entry.update(e => ({ ...e, labels: [this.typeForm?.getRawValue().type] }));
-    this.entry.update(e => ({ ...e, properties: { ...e.properties, ...properties } }));
+    this.entry.update(e => ({ ...e, attributes: { ...e.attributes, ...attributes } }));
   }
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.html
@@ -94,30 +94,32 @@
         </div>
       </div>
 
-      <div class="row">
-        <div class="form-group col-6">
-          <div class="form-check">
-            <input type="checkbox"
-                   class="form-check-input"
-                   formControlName="isArray"
-                   id="isArray"
-                   name="isArray">
-            <label class="form-check-label" for="isArray">Is Array?</label>
-          </div>
 
-          <div class="form-check">
-            <input type="checkbox"
-                   class="form-check-input"
-                   formControlName="isMandatory"
-                   id="isMandatory"
-                   name="isMandatory">
-            <label class="form-check-label" for="isMandatory">Is Mandatory?</label>
-          </div>
-        </div>
+      <!-- isMandatory -->
+      <div class="form-check col-12">
+        <input type="checkbox"
+                class="form-check-input"
+                formControlName="isMandatory"
+                id="isMandatory"
+                name="isMandatory">
+        <label class="form-check-label" for="isMandatory">Is Mandatory?</label>
       </div>
 
-      <div class="row">
-        <div class="form-group col-6">
+      <!-- isArray - ENUM only -->
+      @if (isType(ENUM)) {
+        <div class="form-check col-12">
+          <input type="checkbox"
+                class="form-check-input"
+                formControlName="isArray"
+                id="isArray"
+                name="isArray">
+          <label class="form-check-label" for="isArray">Is Array?</label>
+        </div>
+      }
+
+      <!-- valuePattern - STRING only -->
+      @if (isType(STRING)) {
+        <div class="form-group col-12">
           <label class="form-label mt-4" for="valuePattern">Value Pattern:</label>
           <input
             class="form-control"
@@ -133,7 +135,11 @@
             }
           </div>
         </div>
-        <div class="form-group col-6">
+      }
+
+      <!-- valueRange - NUMBER only -->
+      @if (isType(NUMBER)) {
+        <div class="form-group col-12">
           <label class="form-label mt-4" for="valueRange">Value Range:</label>
           <input
             class="form-control"
@@ -149,11 +155,12 @@
             }
           </div>
         </div>
-      </div>
+      }
 
-      <div class="row">
+      <!-- allowedValues - ENUM only -->
+      @if (isType(ENUM)) {
         <div class="form-group col-12">
-          <label class="form-label mt-4" for="valueRange">Allowed Values:</label>
+          <label class="form-label mt-4">Allowed Values:</label>
           @for (allowedValue of attribute()?.allowedValues; track allowedValue) {
             <div class="attribute-allowed-value">
               <button type="button"
@@ -178,7 +185,7 @@
                     (keyup.enter)="addAllowedValue(); false;">
           </div>
         </div>
-      </div>
+      }
 
     </div>
   </form>

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.ts
@@ -38,8 +38,16 @@ export class EditAttributeDialogComponent {
   protected submitted = false;
   protected types: AttributeTypeDTO[] = Object.values(AttributeTypeDTO)
       .filter(t => typeof t !== "number")
-      .map(t => t as unknown as AttributeTypeDTO);
+      .map(t => t as unknown as AttributeTypeDTO)
+      .filter(t => t !== AttributeTypeDTO.WIKIQID);
   protected newAllowedValue: WritableSignal<string> = signal("");
+
+  // Constants
+  protected readonly STRING = AttributeTypeDTO.STRING;
+  protected readonly NUMBER = AttributeTypeDTO.NUMBER;
+  protected readonly ENUM = AttributeTypeDTO.ENUM;
+  protected readonly DATENOTATION = AttributeTypeDTO.DATENOTATION;
+  protected readonly WIKIQID = AttributeTypeDTO.WIKIQID;
 
   // Init
   constructor() {
@@ -130,10 +138,6 @@ export class EditAttributeDialogComponent {
     this.attribute()?.allowedValues?.splice(index, 1);
   }
 
-  // protected createAllowedValue(): void {
-  //   this.newAllowedValue.set("");
-  // }
-
   protected addAllowedValue(): void {
     const newAllowedValue = this.newAllowedValue();
     const attribute = this.attribute();
@@ -143,5 +147,9 @@ export class EditAttributeDialogComponent {
     attribute!.allowedValues = this.attribute()!.allowedValues ?? [];
     attribute!.allowedValues?.push(newAllowedValue!);
     this.newAllowedValue.set("");
+  }
+
+  isType(type: AttributeTypeDTO): boolean {
+    return this.form.get("type")?.value === type;
   }
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-attribute-dialog/edit-attribute-dialog.component.ts
@@ -3,8 +3,10 @@ import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } 
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ApiErrorDTO } from 'src/app/common/model/error-response.dto';
 import { AttributeAO } from 'src/app/common/model/schema/admin/attribute.ao';
 import { AttributeTypeDTO } from 'src/app/common/model/schema/attribute-type.dto';
+import { BackendErrorService } from 'src/app/common/util/backend-error.service';
 import { FormService } from 'src/app/common/util/form.service';
 import { uniqueValidator } from 'src/app/common/util/unique-validator';
 
@@ -24,10 +26,12 @@ export class EditAttributeDialogComponent {
   private fb = inject(FormBuilder);
   private activeModal = inject(NgbActiveModal);
   private formService = inject(FormService);
+  private backendErrorService = inject(BackendErrorService);
 
   // Inputs
   protected attribute: ModelSignal<AttributeAO | undefined> = model();
   protected takenAttributeNames: ModelSignal<string[] | undefined> = model();
+  protected backendErrors: ModelSignal<ApiErrorDTO[]> = model<ApiErrorDTO[]>([]);
 
   // Icons
   protected deleteIcon = faTrash;
@@ -51,6 +55,9 @@ export class EditAttributeDialogComponent {
 
   // Init
   constructor() {
+    effect(() => {
+      console.log("Backend errors in edit attribute dialog changed:", this.backendErrors());
+    });
     this.form = this.fb.group({
       key: [null,
         [
@@ -121,11 +128,14 @@ export class EditAttributeDialogComponent {
 
   protected isInvalid(field: string): boolean {
     const ctrl = this.form.get(field);
-    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched));
+    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched)) || this.hasBackendError(field);
   }
 
   protected errors(field: string, label: string): string[] {
-    return this.formService.extractErrors(field, label, this.form);
+    return [
+      ...this.formService.extractErrors(field, label, this.form),
+      ...this.backendErrorService.extractErrors(field, label, this.backendErrors())
+    ];
   }
 
   protected isNew = computed(() => !this.attribute()?.id);
@@ -149,7 +159,12 @@ export class EditAttributeDialogComponent {
     this.newAllowedValue.set("");
   }
 
-  isType(type: AttributeTypeDTO): boolean {
+  protected isType(type: AttributeTypeDTO): boolean {
     return this.form.get("type")?.value === type;
   }
+
+  protected hasBackendError(field: string): boolean {
+    return this.backendErrors()?.some(e => e.field === field);
+  }
+
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.html
@@ -116,9 +116,12 @@
           </tr>
         </thead>
         <tbody>
-          @for (attribute of relation().attributes; track attribute.key) {
-            <tr class="pointer">
+          @for (attribute of relation().attributes; track attribute.key; let i = $index) {
+            <tr class="pointer"
+                [class.invalid]="hasBackendErrorMatching(`attributes[${i}]`)">
               <td (click)="editAttribute(attribute)">
+                <fa-icon [icon]="warnIcon"
+                        class="if-invalid"></fa-icon>
                 {{ attribute.key }}
               </td>
               <td (click)="editAttribute(attribute)">

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.scss
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.scss
@@ -41,3 +41,16 @@ tr.default-attr > td {
   color: variables.$gray-600;
 }
 
+
+tr.invalid > * {
+  color: variables.$red;
+  background-color: variables.$warn-background;
+
+  .if-invalid {
+    display: inline !important;
+  }
+}
+
+.if-invalid {
+  display: none;
+}

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.ts
@@ -42,6 +42,7 @@ export class EditRelationOffcanvasComponent {
   protected cancelIcon = IconsConfig.ICON_CANCEL;
   protected editIcon = IconsConfig.ICON_EDIT;
   protected deleteIcon = IconsConfig.ICON_DELETE;
+  protected warnIcon = IconsConfig.ICON_WARNING;
 
   // Form & controls
   protected submitted = false;
@@ -117,6 +118,8 @@ export class EditRelationOffcanvasComponent {
     modalRef.componentInstance.attribute.set(attr);
     const takenAttributeNames = this.relation()?.attributes?.filter(a => a !== attr).map(a => a.key);
     modalRef.componentInstance.takenAttributeNames.set(takenAttributeNames);
+    const backendErrors = this.getBackendErrorsSection(`attributes[${this.relation()?.attributes?.indexOf(attr)}]`);
+    modalRef.componentInstance.backendErrors.set(backendErrors);
 
     modalRef.result.then(resultAttribute => {
       if (!resultAttribute) {
@@ -156,6 +159,19 @@ export class EditRelationOffcanvasComponent {
 
   protected hasBackendError(field: string): boolean {
     return this.backendErrors()?.some(e => e.field === field);
+  }
+
+  protected hasBackendErrorMatching(path: string): boolean {
+    return this.backendErrors().some(e => e.field.startsWith(path));
+  }
+
+  private getBackendErrorsSection(fieldPathPrefix: string): ApiErrorDTO[] {
+    return this.backendErrors()
+      .filter(e => e.field.startsWith(fieldPathPrefix))
+      .map(e => ({
+        ...e,
+        field: e.field.replace(`${fieldPathPrefix}.`, '')
+      }));
   }
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-relation-offcanvas/edit-relation-offcanvas.component.ts
@@ -10,6 +10,8 @@ import { IconConstants as IconsConfig } from 'src/app/common/constants/icon.cons
 import { EditAttributeDialogComponent } from '../edit-attribute-dialog/edit-attribute-dialog.component';
 import { AdminConfirmService } from 'src/app/modules/admin/services/admin-confirm.service';
 import { TypeSelectComponent } from '../type-select/type-select.component';
+import { BackendErrorService } from 'src/app/common/util/backend-error.service';
+import { ApiErrorDTO } from 'src/app/common/model/error-response.dto';
 
 @Component({
   selector: 'chronos-edit-relation-offcanvas',
@@ -26,12 +28,14 @@ export class EditRelationOffcanvasComponent {
 	protected offcanvas = inject(NgbActiveOffcanvas);
   private fb = inject(FormBuilder);
   private formService = inject(FormService);
+  private backendErrorService = inject(BackendErrorService);
   private modalService = inject(NgbModal);
   private adminConfirmService = inject(AdminConfirmService);
 
   // Inputs
   protected relation: ModelSignal<RelationAO> = model({});
   protected takenKeys: ModelSignal<string[]> = model([] as string[]);
+  protected backendErrors: ModelSignal<ApiErrorDTO[]> = model<ApiErrorDTO[]>([]);
 
   // Icons
   protected saveIcon = IconsConfig.ICON_SAVE;
@@ -81,11 +85,14 @@ export class EditRelationOffcanvasComponent {
   // Methods
   protected isInvalid(field: string): boolean {
     const ctrl = this.form?.get(field);
-    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched));
+    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched)) || this.hasBackendError(field);
   }
 
   protected errors(field: string, label: string): string[] {
-    return this.formService.extractErrors(field, label, this.form);
+    return [
+      ...this.formService.extractErrors(field, label, this.form),
+      ...this.backendErrorService.extractErrors(field, label, this.backendErrors())
+    ];
   }
 
   protected confirm(): void {
@@ -145,6 +152,10 @@ export class EditRelationOffcanvasComponent {
         // Nothing todo
       }
     )
+  }
+
+  protected hasBackendError(field: string): boolean {
+    return this.backendErrors()?.some(e => e.field === field);
   }
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
@@ -37,7 +37,14 @@
       <fa-icon [icon]="saveIcon"></fa-icon>
       Save & return
     </button>
+    @if (!form?.valid) {
+      <button class="btn btn-outline-warning"
+              (click)="toggleForceDisplayErrors()">
+        <fa-icon [icon]="helpIcon"></fa-icon>
+      </button>
+    }
   </div>
+
 </div>
 
 @if (typeResource.isLoading()) {

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
@@ -23,12 +23,21 @@
     <fa-icon [icon]="cancelIcon"></fa-icon>
     Cancel
   </button>
-  <button class="btn btn-outline-success"
-          (click)="save()"
-          [disabled]="!form?.valid">
-    <fa-icon [icon]="saveIcon"></fa-icon>
-    Save
-  </button>
+
+  <div class="btn-group" role="group">
+    <button class="btn btn-outline-success"
+            (click)="save(false)"
+            [disabled]="!form?.valid">
+      <fa-icon [icon]="saveIcon"></fa-icon>
+      Save
+    </button>
+    <button class="btn btn-success"
+            (click)="save(true)"
+            [disabled]="!form?.valid">
+      <fa-icon [icon]="saveIcon"></fa-icon>
+      Save & return
+    </button>
+  </div>
 </div>
 
 @if (typeResource.isLoading()) {

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.html
@@ -155,9 +155,12 @@
         </tr>
       </thead>
       <tbody>
-        @for (attribute of type.attributes; track attribute.key) {
-          <tr class="pointer">
+        @for (attribute of type.attributes; track attribute.key; let i = $index) {
+          <tr class="pointer"
+              [class.invalid]="hasBackendErrorMatching(`attributes[${i}]`)">
             <td (click)="editAttribute(attribute)">
+              <fa-icon [icon]="warnIcon"
+                       class="if-invalid"></fa-icon>
               {{ attribute.key }}
             </td>
             <td (click)="editAttribute(attribute)">
@@ -217,9 +220,12 @@
         </tr>
       </thead>
       <tbody>
-        @for (relation of type.relations; track relation.key) {
-          <tr class="pointer">
+        @for (relation of type.relations; track relation.key; let i = $index) {
+          <tr class="pointer"
+              [class.invalid]="hasBackendErrorMatching(`relations[${i}]`)">
             <td (click)="editRelation(relation)">
+              <fa-icon [icon]="warnIcon"
+                       class="if-invalid"></fa-icon>
               {{ relation.key }}
             </td>
             <td (click)="editRelation(relation)">

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.scss
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.scss
@@ -14,3 +14,16 @@ table td:last-child {
 tr.default-attr > td {
   color: variables.$gray-600;
 }
+
+tr.invalid > * {
+  color: variables.$red;
+  background-color: variables.$warn-background;
+
+  .if-invalid {
+    display: inline !important;
+  }
+}
+
+.if-invalid {
+  display: none;
+}

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -120,15 +120,6 @@ export class EditTypeComponent {
     });
   }
 
-  private getBackendErrorsSection(fieldPathPrefix: string): ApiErrorDTO[] {
-    return this.backendErrors()
-      .filter(e => e.field.startsWith(fieldPathPrefix))
-      .map(e => ({
-        ...e,
-        field: e.field.replace(`${fieldPathPrefix}.`, '')
-      }));
-  }
-
   protected editAttribute(attr: AttributeAO): void {
     const modalRef = this.modalService.open(EditAttributeDialogComponent);
     modalRef.componentInstance.attribute.set(attr);
@@ -313,6 +304,15 @@ export class EditTypeComponent {
 
   protected toggleForceDisplayErrors(): void {
     this.forceDisplayErrors = !this.forceDisplayErrors;
+  }
+
+  private getBackendErrorsSection(fieldPathPrefix: string): ApiErrorDTO[] {
+    return this.backendErrors()
+      .filter(e => e.field.startsWith(fieldPathPrefix))
+      .map(e => ({
+        ...e,
+        field: e.field.replace(`${fieldPathPrefix}.`, '')
+      }));
   }
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -51,6 +51,7 @@ export class EditTypeComponent {
   protected editIcon = IconConstants.ICON_EDIT;
   protected deleteIcon = IconConstants.ICON_DELETE;
   protected helpIcon = IconConstants.ICON_QUESTION;
+  protected warnIcon = IconConstants.ICON_WARNING;
 
   // Derived Data Fields
   protected typeId = toSignal(
@@ -291,6 +292,10 @@ export class EditTypeComponent {
 
   protected hasBackendError(field: string): boolean {
     return this.backendErrors().some(e => e.field === field);
+  }
+
+  protected hasBackendErrorMatching(path: string): boolean {
+    return this.backendErrors().some(e => e.field.startsWith(path));
   }
 
   protected toggleForceDisplayErrors(): void {

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -50,7 +50,7 @@ export class EditTypeComponent {
   protected cancelIcon = IconConstants.ICON_CANCEL;
   protected editIcon = IconConstants.ICON_EDIT;
   protected deleteIcon = IconConstants.ICON_DELETE;
-  protected helpIcon = IconConstants.ICON_QUESTION;
+  protected helpIcon = IconConstants.ICON_HELP;
   protected warnIcon = IconConstants.ICON_WARNING;
 
   // Derived Data Fields

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -120,18 +120,21 @@ export class EditTypeComponent {
     });
   }
 
+  private getBackendErrorsSection(fieldPathPrefix: string): ApiErrorDTO[] {
+    return this.backendErrors()
+      .filter(e => e.field.startsWith(fieldPathPrefix))
+      .map(e => ({
+        ...e,
+        field: e.field.replace(`${fieldPathPrefix}.`, '')
+      }));
+  }
+
   protected editAttribute(attr: AttributeAO): void {
     const modalRef = this.modalService.open(EditAttributeDialogComponent);
     modalRef.componentInstance.attribute.set(attr);
     const takenAttributeNames = this.typeResource.value()?.attributes?.filter(a => a !== attr).map(a => a.key);
     modalRef.componentInstance.takenAttributeNames.set(takenAttributeNames);
-    const errorPrefix = `attributes[${this.typeResource.value()?.attributes?.indexOf(attr)}]`;
-    const backendErrors = this.backendErrors()
-      .filter(e => e.field.startsWith(errorPrefix))
-      .map(e => ({
-        ...e,
-        field: e.field.replace(`${errorPrefix}.`, '')
-      }));
+    const backendErrors = this.getBackendErrorsSection(`attributes[${this.typeResource.value()?.attributes?.indexOf(attr)}]`);
     modalRef.componentInstance.backendErrors.set(backendErrors);
 
     modalRef.result.then(resultAttribute => {
@@ -172,6 +175,8 @@ export class EditTypeComponent {
     const takenKeys = this.typeResource.value()?.relations?.filter(a => a !== rel).map(a => a.key);
 		offcanvasRef.componentInstance.relation.set(rel);
 		offcanvasRef.componentInstance.takenKeys.set(takenKeys);
+    const backendErrors = this.getBackendErrorsSection(`relations[${this.typeResource.value()?.relations?.indexOf(rel)}]`);
+    offcanvasRef.componentInstance.backendErrors.set(backendErrors);
 
     offcanvasRef.result.then(resultRelation => {
       if (!resultRelation) {

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -47,6 +47,7 @@ export class EditTypeComponent {
   protected cancelIcon = IconConstants.ICON_CANCEL;
   protected editIcon = IconConstants.ICON_EDIT;
   protected deleteIcon = IconConstants.ICON_DELETE;
+  protected helpIcon = IconConstants.ICON_QUESTION;
 
   // Derived Data Fields
   protected typeId = toSignal(
@@ -71,6 +72,7 @@ export class EditTypeComponent {
   protected form?: FormGroup;
   protected currentAttribute: WritableSignal<AttributeAO | undefined> = signal(undefined);
   protected submitted = false;
+  protected forceDisplayErrors = false;
 
   // Init
   constructor() {
@@ -273,11 +275,15 @@ export class EditTypeComponent {
 
   protected isInvalid(field: string): boolean {
     const ctrl = this.form?.get(field);
-    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched));
+    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched || this.forceDisplayErrors));
   }
 
   protected errors(field: string, label: string): string[] {
     return this.formService.extractErrors(field, label, this.form);
+  }
+
+  protected toggleForceDisplayErrors(): void {
+    this.forceDisplayErrors = !this.forceDisplayErrors;
   }
 
 }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -17,6 +17,8 @@ import { FormService } from 'src/app/common/util/form.service';
 import { RelationAO } from 'src/app/common/model/schema/admin/relation.ao';
 import { EditRelationOffcanvasComponent } from './edit-relation-offcanvas/edit-relation-offcanvas.component';
 import { IconSelectComponent } from "./icon-select/icon-select.component";
+import { ApiErrorDTO, ErrorResponseDTO } from 'src/app/common/model/error-response.dto';
+import { BackendErrorService } from 'src/app/common/util/backend-error.service';
 
 @Component({
   selector: 'chronos-edit-type',
@@ -40,6 +42,7 @@ export class EditTypeComponent {
   private fb = inject(FormBuilder);
   private modalService = inject(NgbModal);
   private formService = inject(FormService);
+  private backendErrorService = inject(BackendErrorService);
 	private offcanvasService = inject(NgbOffcanvas);
 
   // Icons
@@ -67,6 +70,7 @@ export class EditTypeComponent {
            ?? []
   });
   protected isNew = computed(() => !this.typeResource.value()?.id);
+  protected backendErrors: WritableSignal<ApiErrorDTO[]> = signal([]);
 
   // Form & controls
   protected form?: FormGroup;
@@ -196,8 +200,8 @@ export class EditTypeComponent {
           this.back();
         }
       },
-      (err) => {
-        // Nothing todo
+      (err: ErrorResponseDTO) => {
+        this.backendErrors.set(err.error.errors ?? []);
       }
     );
   }
@@ -275,11 +279,18 @@ export class EditTypeComponent {
 
   protected isInvalid(field: string): boolean {
     const ctrl = this.form?.get(field);
-    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched || this.forceDisplayErrors));
+    return !!(ctrl?.invalid && (this.submitted || ctrl?.touched || this.forceDisplayErrors)) || this.hasBackendError(field);
   }
 
   protected errors(field: string, label: string): string[] {
-    return this.formService.extractErrors(field, label, this.form);
+    return [
+      ...this.formService.extractErrors(field, label, this.form),
+      ...this.backendErrorService.extractErrors(field, label, this.backendErrors())
+    ];
+  }
+
+  protected hasBackendError(field: string): boolean {
+    return this.backendErrors().some(e => e.field === field);
   }
 
   protected toggleForceDisplayErrors(): void {

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -125,6 +125,14 @@ export class EditTypeComponent {
     modalRef.componentInstance.attribute.set(attr);
     const takenAttributeNames = this.typeResource.value()?.attributes?.filter(a => a !== attr).map(a => a.key);
     modalRef.componentInstance.takenAttributeNames.set(takenAttributeNames);
+    const errorPrefix = `attributes[${this.typeResource.value()?.attributes?.indexOf(attr)}]`;
+    const backendErrors = this.backendErrors()
+      .filter(e => e.field.startsWith(errorPrefix))
+      .map(e => ({
+        ...e,
+        field: e.field.replace(`${errorPrefix}.`, '')
+      }));
+    modalRef.componentInstance.backendErrors.set(backendErrors);
 
     modalRef.result.then(resultAttribute => {
       if (!resultAttribute) {
@@ -202,7 +210,7 @@ export class EditTypeComponent {
         }
       },
       (err: ErrorResponseDTO) => {
-        this.backendErrors.set(err.error.errors ?? []);
+        this.backendErrors.set(err.error?.errors ?? []);
       }
     );
   }

--- a/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
+++ b/chronos-frontend/src/app/modules/admin/views/schema/edit-type/edit-type.component.ts
@@ -185,12 +185,14 @@ export class EditTypeComponent {
   }
 
   // Methods
-  protected save(): void {
+  protected save(returnAfterSave: boolean = false): void {
     this.submitted = true;
     const type = EditTypeFormMapper.toAO(this.form?.getRawValue(), this.typeResource.value());
     firstValueFrom(this.schemaService.saveType(type)).then(
       () => {
-        this.back();
+        if (returnAfterSave) {
+          this.back();
+        }
       },
       (err) => {
         // Nothing todo

--- a/chronos-frontend/src/app/modules/public/clients/historical-data.client.ts
+++ b/chronos-frontend/src/app/modules/public/clients/historical-data.client.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CountResultDTO } from 'src/app/common/model/data/count-result.dto';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 import { DataResponseDTO } from 'src/app/common/model/data/data-response.dto';
 import { QueryDTO } from 'src/app/common/model/data/query.model.dto';
 

--- a/chronos-frontend/src/app/modules/public/services/historical-data.service.ts
+++ b/chronos-frontend/src/app/modules/public/services/historical-data.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, ResourceRef, Signal } from '@angular/core';
 import { QueryDTO } from 'src/app/common/model/data/query.model.dto';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 import { CountResultDTO } from 'src/app/common/model/data/count-result.dto';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { HistoricalDataClient } from '../clients/historical-data.client';

--- a/chronos-frontend/src/app/modules/public/services/wiki-article.service.ts
+++ b/chronos-frontend/src/app/modules/public/services/wiki-article.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, ResourceRef, Signal } from '@angular/core';
 import { QueryDTO } from 'src/app/common/model/data/query.model.dto';
-import { EntryDTO } from 'src/app/common/model/data/data-element.dto';
+import { EntryDTO } from 'src/app/common/model/data/entry.dto';
 import { CountResultDTO } from 'src/app/common/model/data/count-result.dto';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { HistoricalDataClient } from '../clients/historical-data.client';
@@ -28,7 +28,7 @@ export class WikiArticleService {
         }).pipe(
             switchMap(response => {
               const entity = response.entries[0];
-              return this.wikiArticlesClient.getArticleByQid(entity.properties["wikiqid"]!)
+              return this.wikiArticlesClient.getArticleByQid(entity.attributes["wikiqid"]!)
             })
         );
       },

--- a/chronos-frontend/src/app/theme/_variables.scss
+++ b/chronos-frontend/src/app/theme/_variables.scss
@@ -41,6 +41,8 @@ $dark:          $gray-800 !default;
 
 $min-contrast-ratio:   1.45 !default;
 
+$warn-background: rgba(255, 120, 81, 0.1) !default;
+
 // Body
 
 $body-color:                $gray-600 !default;

--- a/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/model/Entry.java
+++ b/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/model/Entry.java
@@ -11,5 +11,5 @@ import java.util.Set;
 public class Entry {
     String elementId;
     Set<String> labels = new HashSet<>();
-    Map<String, Object> properties = new HashMap<>();
+    Map<String, Object> attributes = new HashMap<>();
 }

--- a/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/CypherDslUtils.java
+++ b/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/CypherDslUtils.java
@@ -27,7 +27,7 @@ public class CypherDslUtils {
     }
 
     private static Condition mapFilterToCondition(Filter filter, Node node) {
-        Property property = node.property(filter.getAttribute());
+        Property property = node.property(Cypher.literalOf(filter.getAttribute()));
         // specific null value handling
         if (null == filter.getValue()) {
             switch (filter.getOperator()) {
@@ -75,7 +75,7 @@ public class CypherDslUtils {
         if (sorting != null && sorting.getSortBy() != null) {
             var direction = sorting.getSortOrder() == SortOrder.ASC ? SortItem.Direction.ASC : SortItem.Direction.DESC;
             var property = sorting.getSortBy();
-            var sort = "random".equals(property) ? Cypher.sort(Cypher.rand()) : Cypher.sort(n.property(property), direction);
+            var sort = "random".equals(property) ? Cypher.sort(Cypher.rand()) : Cypher.sort(n.property(Cypher.literalOf(property)), direction);
             sortList.add(sort);
         }
         return sortList;

--- a/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/DataService.java
+++ b/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/DataService.java
@@ -85,7 +85,7 @@ public class DataService {
         // TODO: Schema validation
         var nodeName = "n";
         var label = entry.getLabels().stream().findFirst().orElseThrow(InvalidDataException::new);
-        var n = Cypher.node(label).named(nodeName).withProperties(entry.getProperties());
+        var n = Cypher.node(label).named(nodeName).withProperties(entry.getAttributes());
 
         var statement = Cypher.create(n).returning(n).build();
 

--- a/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/DataService.java
+++ b/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/DataService.java
@@ -85,7 +85,6 @@ public class DataService {
         // TODO: Schema validation
         var nodeName = "n";
         var label = entry.getLabels().stream().findFirst().orElseThrow(InvalidDataException::new);
-        // TODO: Map values to Cypher.parameter
         var n = Cypher.node(label).named(nodeName).withProperties(entry.getProperties());
 
         var statement = Cypher.create(n).returning(n).build();

--- a/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/ResultMapper.java
+++ b/chronos-historical-data-service/src/main/java/net/fvogel/chronos/data/service/ResultMapper.java
@@ -22,7 +22,7 @@ public class ResultMapper {
         Entry entry = new Entry();
         entry.setElementId(node.elementId());
         node.labels().forEach(label -> entry.getLabels().add(label));
-        node.keys().forEach(key -> entry.getProperties().put(key, value(node.get(key))));
+        node.keys().forEach(key -> entry.getAttributes().put(key, value(node.get(key))));
         return entry;
     }
 

--- a/chronos-historical-data-service/src/main/resources/application-debug.properties
+++ b/chronos-historical-data-service/src/main/resources/application-debug.properties
@@ -4,4 +4,4 @@ logging.level.org.springframework.data.neo4j=DEBUG
 # SECURITY
 logging.level.org.springframework.security=DEBUG
 # APP
-logging.level.net.fvogel.chronos.data.service=DEBUG
+logging.level.net.fvogel.chronos.data.persistence=DEBUG

--- a/chronos-historical-data-service/src/main/resources/testdata/testdata.cql
+++ b/chronos-historical-data-service/src/main/resources/testdata/testdata.cql
@@ -1,87 +1,265 @@
-// Early Rome
-CREATE (RomanEmpire:Territory {id: 'rmnmpr', key: 'roman-empire'})
-CREATE (Otho:Person {id:      'th',
-                     key:     'otho',
-                     from:    '0032-04-28',
-                     to:      '0069-04-16',
-                     wikiqid: 'Q1416',
-                     name:    'Marcus Salvius Otho'})
-CREATE (Vitellius:Person {id:      'vtlls',
-                          key:     'vitellius',
-                          from:    '0015-09-27',
-                          to:      '0069-12-20',
-                          wikiqid: 'Q1417',
-                          name:    'Aulus Vitellius'})
-CREATE (Vespasian:Person {id:   'vspsn', key: 'vespasian', from: '0009-09-17', to: '0079-07-23', wikiqid: 'Q1419',
-                          name: 'Titus Flavius Vespasianus'})
-CREATE(Titus:Person {id:   'tts', key: 'titus', from: '0039-12-30', to: '0081-09-13', wikiqid: 'Q1421',
-                     name: 'Titus Flavius Vespasianus'})
-CREATE (Domitian:Person {id:   'dmtn', key: 'domitian', from: '0051-10-24', to: '0096-09-18',
-                         name: 'Titus Flavius Domitianus'})
-CREATE (Domitilla:Person {id: 'dmtll', key: 'domitilla-the-elder', name: 'Flavia Domitilla Major'})
-CREATE (Caenis:Person {id: 'cns', key: 'caenis', to: '0074', name: 'Antonia Caenis'})
+//// EARLY ROME
+// Nodes
+CREATE (RomanEmpire:Territory {
+  key: 'roman-empire'
+})
+CREATE (Otho:Person {
+  key:     'otho',
+  from:    '0032-04-28',
+  to:      '0069-04-16',
+  wikiqid: 'Q1416',
+  name:    'Marcus Salvius Otho'
+})
+CREATE (Vitellius:Person {
+  key:     'vitellius',
+  from:    '0015-09-27',
+  to:      '0069-12-20',
+  wikiqid: 'Q1417',
+  name:    'Aulus Vitellius'
+})
+CREATE (Vespasian:Person {
+  key:     'vespasian',
+  from:    '0009-09-17',
+  to:      '0079-07-23',
+  wikiqid: 'Q1419',
+  name:    'Titus Flavius Vespasianus'
+})
+CREATE(Titus:Person {
+  key:     'titus',
+  from:    '0039-12-30',
+  to:      '0081-09-13',
+  wikiqid: 'Q1421',
+  name:    'Titus Flavius Vespasianus'
+})
+CREATE (Domitian:Person {
+  key:  'domitian',
+  from: '0051-10-24',
+  to:   '0096-09-18',
+  name: 'Titus Flavius Domitianus'
+})
+CREATE (Domitilla:Person {
+  key:  'domitilla-the-elder',
+  name: 'Flavia Domitilla Major'
+})
+CREATE (Caenis:Person {
+  key:  'caenis',
+  to:   '0074',
+  name: 'Antonia Caenis'
+})
 
-// Reigns
-CREATE (Otho)-[:RULED {titles: ['emperor'], from: '0069-01-15', to: '0069-04-16'}]->(RomanEmpire)
-CREATE (Vitellius)-[:RULED {titles: ['emperor'], from: '0069-04-19', to: '0069-12-20'}]->(RomanEmpire)
-CREATE (Vespasian)-[:RULED {titles: ['emperor']}]->(RomanEmpire)
-CREATE (Titus)-[:RULED {titles: ['emperor']}]->(RomanEmpire)
-CREATE (Domitian)-[:RULED {titles: ['emperor']}]->(RomanEmpire)
+// Relations: RULED
+CREATE (Otho)-[:RULED {
+  titles: ['emperor'],
+  from:   '0069-01-15',
+  to:     '0069-04-16'
+}]->(RomanEmpire)
+CREATE (Vitellius)-[:RULED {
+  titles: ['emperor'],
+  from:   '0069-04-19',
+  to:     '0069-12-20'
+}]->(RomanEmpire)
+CREATE (Vespasian)-[:RULED {
+  titles: ['emperor']
+}]->(RomanEmpire)
+CREATE (Titus)-[:RULED {
+  titles: ['emperor']
+}]->(RomanEmpire)
+CREATE (Domitian)-[:RULED {
+  titles: ['emperor']
+}]->(RomanEmpire)
 
 // Flavian Family
-CREATE (Vespasian)-[:MARRIED_TO]->(Domitilla)
-CREATE (Vespasian)-[:RELATIONSHIP_WITH]->(Caenis)
-//CREATE (Titus)-[:CHILD_OF {type: 'BIOLOGICAL'}]->(Domitilla)
-CREATE (Titus)-[:CHILD_OF {type: 'BIOLOGICAL'}]->(Vespasian)
-//CREATE (Domitian)-[:CHILD_OF {type: 'BIOLOGICAL'}]->(Domitilla)
-CREATE (Domitian)-[:CHILD_OF {type: 'BIOLOGICAL'}]->(Vespasian)
+// Relations: RELATIONSHIP_WITH
+CREATE (Vespasian)-[:RELATIONSHIP_WITH {
+  status: 'married'
+}]->(Domitilla)
+CREATE (Vespasian)-[:RELATIONSHIP_WITH {
+  status: 'cohabitation'
+}]->(Caenis)
+
+// Relations: CHILD_OF
+CREATE (Titus)-[:CHILD_OF {
+  type: 'biological'
+}]->(Domitilla)
+CREATE (Titus)-[:CHILD_OF {
+  type: 'biological'
+}]->(Vespasian)
+CREATE (Domitian)-[:CHILD_OF {
+  type: 'biological'
+}]->(Domitilla)
+CREATE (Domitian)-[:CHILD_OF {
+  type: 'biological'
+}]->(Vespasian)
 
 
 
-// Crisis of 3rd century
-CREATE (ValerianI:Person {key: 'valerian-i', from: '019*', to: '0260', name: 'Publius Licinius Valerianus'})
-CREATE (Gallienus:Person {key: 'gallienus', from: '0218', to: '0268', name: 'Publius Licinius Egnatius Gallienus'})
-CREATE (ClaudiusGothicus:Person {key: 'claudius-gothicus', from: '0214', to: '0270', name: 'Marcus Aurelius Claudius'})
-CREATE (Quintillus:Person {key: 'quintillus', from: '022*', to: '0270', name: 'Marcus Aurelius Claudius Quintillus'})
-CREATE (Aurelian:Person {key: 'aurelian', from: '0214', to: '0275', name: 'Lucius Domitius Aurelianus'})
-CREATE (Tacitus:Person {key: 'tacitus', from: '0200', to: '0276', name: 'Marcus Claudius Tacitus'})
+//// CRISIS OF 3RD CENTURY
+// Nodes
+CREATE (ValerianI:Person {
+  key:  'valerian-i',
+  from: '019*',
+  to:   '0260',
+  name: 'Publius Licinius Valerianus'
+})
+CREATE (Gallienus:Person {
+  key:  'gallienus',
+  from: '0218',
+  to:   '0268',
+  name: 'Publius Licinius Egnatius Gallienus'
+})
+CREATE (ClaudiusGothicus:Person {
+  key:  'claudius-gothicus',
+  from: '0214',
+  to:   '0270',
+  name: 'Marcus Aurelius Claudius'
+})
+CREATE (Quintillus:Person {
+  key:  'quintillus',
+  from: '022*',
+  to:   '0270',
+  name: 'Marcus Aurelius Claudius Quintillus'
+})
+CREATE (Aurelian:Person {
+  key:  'aurelian',
+  from: '0214',
+  to:   '0275',
+  name: 'Lucius Domitius Aurelianus'
+})
+CREATE (Tacitus:Person {
+  key:  'tacitus',
+  from: '0200',
+  to:   '0276',
+  name: 'Marcus Claudius Tacitus'
+})
 
-////// REL: RULED
-CREATE (ValerianI)-[:RULED {titles: ['emperor'], from: '0253', to: '0260'}]->(RomanEmpire)
-CREATE (Gallienus)-[:RULED {titles: ['emperor'], from: '0253', to: '0268'}]->(RomanEmpire)
-CREATE (ClaudiusGothicus)-[:RULED {titles: ['emperor'], from: '0268', to: '0270'}]->(RomanEmpire)
-CREATE (Quintillus)-[:RULED {titles: ['emperor'], from: '0270', to: '0270'}]->(RomanEmpire)
-CREATE (Aurelian)-[:RULED {titles: ['emperor'], from: '0270', to: '0275'}]->(RomanEmpire)
-CREATE (Tacitus)-[:RULED {titles: ['emperor'], from: '0275', to: '0276'}]->(RomanEmpire)
+// Relations: RULED
+CREATE (ValerianI)-[:RULED {
+  titles: ['emperor'],
+  from:   '0253',
+  to:     '0260'
+}]->(RomanEmpire)
+CREATE (Gallienus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0253', to:
+          '0268'
+}]->(RomanEmpire)
+CREATE (ClaudiusGothicus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0268',
+  to:     '0270'
+}]->(RomanEmpire)
+CREATE (Quintillus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0270',
+  to:     '0270'
+}]->(RomanEmpire)
+CREATE (Aurelian)-[:RULED {
+  titles: ['emperor'],
+  from:   '0270',
+  to:     '0275'
+}]->(RomanEmpire)
+CREATE (Tacitus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0275',
+  to:     '0276'
+}]->(RomanEmpire)
+
 
 
 //// Gallic Empire
-CREATE (GallicEmpire:Territory {key: 'gallic-empire', from: '0267', to: '0273'})
-CREATE (Postumus:Person {key: 'postumus', to: '0269', name: 'Marcus Cassianius Latinius Postumus'})
-CREATE (Marius:Person {key: 'marius', to: '0269', name: 'Marcus Aurelius Marius'})
-CREATE (Victorinus:Person {key: 'victorinus', from: '02**', to: '0270|0271', name: 'Marcus Piavonius Victorinus'})
-CREATE (Tetricus:Person {key: 'tetricus', to: '0274', name: 'Gaius Pius Esuvius Tetricus'})
+// Nodes
+CREATE (GallicEmpire:Territory {
+  key:  'gallic-empire',
+  from: '0267',
+  to:   '0273'
+})
+CREATE (Postumus:Person {
+  key:  'postumus',
+  to:   '0269',
+  name: 'Marcus Cassianius Latinius Postumus'
+})
+CREATE (Marius:Person {
+  key:  'marius',
+  to:   '0269',
+  name: 'Marcus Aurelius Marius'
+})
+CREATE (Victorinus:Person {
+  key:  'victorinus',
+  from: '02**',
+  to:   '0270|0271',
+  name: 'Marcus Piavonius Victorinus'
+})
+CREATE (Tetricus:Person {
+  key:  'tetricus',
+  to:   '0274',
+  name: 'Gaius Pius Esuvius Tetricus'
+})
 
-////// REL: SECESSIONAL_TO
+// Relations: RULED
+CREATE (Postumus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0260',
+  to:     '0269'
+}]->(GallicEmpire)
+CREATE (Marius)-[:RULED {
+  titles: ['emperor'],
+  from:   '0269',
+  to:     '0269'
+}]->(GallicEmpire)
+CREATE (Victorinus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0269',
+  to:     '0270'
+}]->(GallicEmpire)
+CREATE (Tetricus)-[:RULED {
+  titles: ['emperor'],
+  from:   '0270',
+  to:     '0274'
+}]->(GallicEmpire)
+
+
+
+// Palmyrene Empire
+// Nodes
+CREATE (PalmyreneEmpire:Territory {
+  key:  'palmyrene-empire',
+  from: '0260',
+  to:   '0274'
+})
+CREATE (Vaballathus:Person {
+  key:  'vaballathus',
+  from: '0259',
+  to:   '0274',
+  name: 'Septimius Vaballathus'
+})
+CREATE (Zenobia:Person {
+  key:  'zenobia',
+  from: '0240',
+  to:   '0274',
+  name: 'Septimia Zenobia'
+})
+CREATE (Antiochus:Person {
+  key:  'antiochus',
+  to:   '0273',
+  name: 'Septimius Antiochus'
+})
+
+// Relations: RULED
+CREATE (Vaballathus)-[:RULED {
+  titles: ['emperor', 'king'],
+  from:   '0267',
+  to:     '0272'
+}]->(PalmyreneEmpire)
+CREATE (Zenobia)-[:RULED {
+  titles: ['emperor', 'king'],
+  from:   '0272',
+  to:     '0273'}]->(PalmyreneEmpire)
+CREATE (Antiochus)-[:RULED {
+  titles: ['emperor', 'king'],
+  from:   '0273',
+  to:     '0273'
+}]->(PalmyreneEmpire)
+
+// Relations: SECESSIONAL_TO
 CREATE (GallicEmpire)-[:SECESSIONAL_TO]->(RomanEmpire)
-
-////// REL: RULED
-CREATE (Postumus)-[:RULED {titles: ['emperor'], from: '0260', to: '0269'}]->(GallicEmpire)
-CREATE (Marius)-[:RULED {titles: ['emperor'], from: '0269', to: '0269'}]->(GallicEmpire)
-CREATE (Victorinus)-[:RULED {titles: ['emperor'], from: '0269', to: '0270'}]->(GallicEmpire)
-CREATE (Tetricus)-[:RULED {titles: ['emperor'], from: '0270', to: '0274'}]->(GallicEmpire)
-
-
-//// Palmyrene Empire
-CREATE (PalmyreneEmpire:Territory {key: 'palmyrene-empire', from: '0260', to: '0274'})
-CREATE (Vaballathus:Person {key: 'vaballathus', from: '0259', to: '0274', name: 'Septimius Vaballathus'})
-CREATE (Zenobia:Person {key: 'zenobia', from: '0240', to: '0274', name: 'Septimia Zenobia'})
-CREATE (Antiochus:Person {key: 'antiochus', to: '0273', name: 'Septimius Antiochus'})
-
-////// REL: SECESSIONAL_TO
 CREATE (PalmyreneEmpire)-[:SECESSIONAL_TO]->(RomanEmpire)
-
-////// REL: RULED
-CREATE (Vaballathus)-[:RULED {titles: ['emperor', 'king'], from: '0267', to: '0272'}]->(PalmyreneEmpire)
-CREATE (Zenobia)-[:RULED {titles: ['empress', 'queen'], from: '0272', to: '0273'}]->(PalmyreneEmpire)
-CREATE (Antiochus)-[:RULED {titles: ['empress', 'queen'], from: '0273', to: '0273'}]->(PalmyreneEmpire)

--- a/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/admin/AdminDataApiCreateEntryIntegrationTest.java
+++ b/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/admin/AdminDataApiCreateEntryIntegrationTest.java
@@ -59,11 +59,11 @@ public class AdminDataApiCreateEntryIntegrationTest extends BaseIntegrationTest 
         assertTrue(dataService.findByKey("test-key").isPresent());
         Entry saveEntry = dataService.findByKey("test-key").get();
         assertThat(saveEntry.getLabels(), is(Set.of("Person")));
-        assertThat(saveEntry.getProperties().get("key"), is("test-key"));
-        assertThat(saveEntry.getProperties().get("string-property"), is("StringStringString"));
-        assertThat(saveEntry.getProperties().get("number-property"), is(13));
-        assertThat(saveEntry.getProperties().get("array-property"), is(List.of(arrayProp)));
-        assertThat(saveEntry.getProperties().get("null-property"), nullValue());
+        assertThat(saveEntry.getAttributes().get("key"), is("test-key"));
+        assertThat(saveEntry.getAttributes().get("string-property"), is("StringStringString"));
+        assertThat(saveEntry.getAttributes().get("number-property"), is(13));
+        assertThat(saveEntry.getAttributes().get("array-property"), is(List.of(arrayProp)));
+        assertThat(saveEntry.getAttributes().get("null-property"), nullValue());
     }
 
 }

--- a/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/bykey/DataApiGetByKeyIntegrationTest.java
+++ b/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/bykey/DataApiGetByKeyIntegrationTest.java
@@ -20,7 +20,7 @@ public class DataApiGetByKeyIntegrationTest extends BaseIntegrationTest {
     void getDataByKeyReturnsMatchingEntry() throws Exception {
         mvc.perform(MockMvcRequestBuilders.get("/api/data/vespasian"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.properties.name").value("Titus Flavius Vespasianus"));
+                .andExpect(jsonPath("$.attributes.name").value("Titus Flavius Vespasianus"));
     }
 
     @Test

--- a/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/sorting/DataApiSortingIntegrationTest.java
+++ b/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/it/sorting/DataApiSortingIntegrationTest.java
@@ -108,7 +108,7 @@ public class DataApiSortingIntegrationTest extends BaseIntegrationTest {
         return objectMapper.readValue(json, DataResponseDTO.class)
                 .getEntries()
                 .stream()
-                .map(entry -> entry.getProperties().get("key").toString())
+                .map(entry -> entry.getAttributes().get("key").toString())
                 .toList();
     }
 

--- a/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/testutils/DataApiRequestMatcher.java
+++ b/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/testutils/DataApiRequestMatcher.java
@@ -58,7 +58,7 @@ public class DataApiRequestMatcher {
     }
 
     private static List<String> extractKeys(MvcResult mvcResult) throws UnsupportedEncodingException {
-        String jsonPath = "$.entries.[*].properties.key";
+        String jsonPath = "$.entries.[*].attributes.key";
         String responseJson = mvcResult.getResponse().getContentAsString();
         Collection<Object> values = JsonPath.read(responseJson, jsonPath);
 

--- a/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/testutils/EntryBuilder.java
+++ b/chronos-historical-data-service/src/test/java/net/fvogel/chronos/data/testutils/EntryBuilder.java
@@ -19,7 +19,7 @@ public class EntryBuilder {
     }
 
     public EntryBuilder withProperty(String key, Object value) {
-        this.entry.getProperties().put(key, value);
+        this.entry.getAttributes().put(key, value);
         return this;
     }
 

--- a/chronos-schema-definition-service/src/main/resources/defaults/relation-attributes.json
+++ b/chronos-schema-definition-service/src/main/resources/defaults/relation-attributes.json
@@ -1,14 +1,5 @@
 [
   {
-    "key": "key",
-    "explanation": "",
-    "examples": "",
-    "type": "STRING",
-    "isArray": false,
-    "isMandatory": true,
-    "valuePattern": null
-  },
-  {
     "key": "start",
     "explanation": "",
     "examples": "",

--- a/chronos-schema-definition-service/src/main/resources/testdata/test-schema.json
+++ b/chronos-schema-definition-service/src/main/resources/testdata/test-schema.json
@@ -6,6 +6,23 @@
         "key": "area",
         "type": "NUMBER",
         "isArray": false
+      },
+      {
+        "key": "name",
+        "type": "STRING",
+        "isArray": false
+      }
+    ],
+    "relations": [
+      {
+        "key": "SECESSIONAL_TO",
+        "attributes": [],
+        "source": {
+          "key": "Territory"
+        },
+        "target": {
+          "key": "Territory"
+        }
       }
     ]
   },
@@ -20,6 +37,11 @@
           "male",
           "female"
         ]
+      },
+      {
+        "key": "name",
+        "type": "STRING",
+        "isArray": false
       }
     ],
     "relations": [
@@ -34,6 +56,26 @@
               "married",
               "affair",
               "cohabitation"
+            ]
+          }
+        ],
+        "source": {
+          "key": "Person"
+        },
+        "target": {
+          "key": "Person"
+        }
+      },
+      {
+        "key": "CHILD_OF",
+        "attributes": [
+          {
+            "key": "status",
+            "type": "ENUM",
+            "isArray": false,
+            "allowedValues": [
+              "biological",
+              "adopted"
             ]
           }
         ],
@@ -66,5 +108,41 @@
         }
       }
     ]
+  },
+  {
+    "key": "TestType",
+    "attributes": [
+      {
+        "key": "enum-scalar-attr",
+        "type": "ENUM",
+        "isArray": false,
+        "allowedValues": [
+          "val1",
+          "val2",
+          "val3"
+        ]
+      },
+      {
+        "key": "enum-array-attr",
+        "type": "ENUM",
+        "isArray": true,
+        "allowedValues": [
+          "arrayVal1",
+          "arrayVal2",
+          "arrayVal3"
+        ]
+      },
+      {
+        "key": "number-attr",
+        "type": "NUMBER",
+        "valueRange": "3-10"
+      },
+      {
+        "key": "string-attr",
+        "type": "STRING",
+        "valuePattern": "[a-zA-Z\\s]{3,10}"
+      }
+    ],
+    "relations": []
   }
 ]

--- a/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/CachingIntegrationTest.java
+++ b/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/CachingIntegrationTest.java
@@ -78,14 +78,14 @@ public class CachingIntegrationTest extends BaseIntegrationTest {
         mvc.perform(get("/api/schema"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.meta.base").value("*"))
-                .andExpect(jsonPath("$.types.elements.length()").value(2));
+                .andExpect(jsonPath("$.types.elements.length()").value(3));
 
         verify(typePORepository, times(1)).findAll();
 
         mvc.perform(get("/api/schema"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.meta.base").value("*"))
-                .andExpect(jsonPath("$.types.elements.length()").value(2));
+                .andExpect(jsonPath("$.types.elements.length()").value(3));
 
         verifyNoMoreInteractions(typePORepository);
     }
@@ -121,7 +121,7 @@ public class CachingIntegrationTest extends BaseIntegrationTest {
         mvc.perform(get("/api/schema"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.meta.base").value("*"))
-                .andExpect(jsonPath("$.types.elements.length()").value(2));
+                .andExpect(jsonPath("$.types.elements.length()").value(3));
 
         verify(typePORepository, times(1)).findAll();
     }
@@ -143,7 +143,7 @@ public class CachingIntegrationTest extends BaseIntegrationTest {
         verify(typePORepository, times(1)).findByKey("Person");
 
         mvc.perform(get("/api/schema")).andExpect(status().isOk())
-                .andExpect(jsonPath("$.types.elements.length()").value(1));
+                .andExpect(jsonPath("$.types.elements.length()").value(2));
         verify(typePORepository, times(1)).findAll();
     }
 

--- a/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/PublicApiIntegrationTest.java
+++ b/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/PublicApiIntegrationTest.java
@@ -16,11 +16,11 @@ public class PublicApiIntegrationTest extends BaseIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.meta.base").value("*"))
 
-                .andExpect(jsonPath("$.types.elements.length()").value(2))
+                .andExpect(jsonPath("$.types.elements.length()").value(3))
                 .andExpect(jsonPath("$.types.defaultAttributes.length()").value(4))
 
-                .andExpect(jsonPath("$.relations.elements.length()").value(2))
-                .andExpect(jsonPath("$.relations.defaultAttributes.length()").value(3));
+                .andExpect(jsonPath("$.relations.elements.length()").value(4))
+                .andExpect(jsonPath("$.relations.defaultAttributes.length()").value(2));
     }
 
     @Test
@@ -32,8 +32,8 @@ public class PublicApiIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.types.elements.length()").value(2))
                 .andExpect(jsonPath("$.types.defaultAttributes.length()").value(4))
 
-                .andExpect(jsonPath("$.relations.elements.length()").value(1))
-                .andExpect(jsonPath("$.relations.defaultAttributes.length()").value(3));
+                .andExpect(jsonPath("$.relations.elements.length()").value(2))
+                .andExpect(jsonPath("$.relations.defaultAttributes.length()").value(2));
     }
 
     @Test

--- a/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/admin/AdminApiTypeUpdateIntegrationTest.java
+++ b/chronos-schema-definition-service/src/test/java/net/fvogel/chronos/schema/it/admin/AdminApiTypeUpdateIntegrationTest.java
@@ -29,8 +29,8 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canUpdateSimpleFieldInExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.setExplanation("An individual human");
 
@@ -43,15 +43,15 @@ public class AdminApiTypeUpdateIntegrationTest {
             // After: Exists, with changed attribute and old relations
             getType("Person").andExpect(status().isOk())
                     .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].explanation").value("An individual human"))
-                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(1))
+                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(2))
                     .andExpect(jsonPath("$.relations.length()").value(2));
         }
 
         @Test
         void cannotManipulateIdInExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.setId(15L);
 
@@ -83,8 +83,8 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canUpdateSimpleFieldInAttributeOfExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.getAttributes().stream().filter(attr -> attr.getKey().equals("gender")).findFirst().get()
                     .setExplanation("The biological sex of the individual human");
@@ -97,7 +97,7 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with changed attribute and old relations
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(1))
+                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(2))
                     .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes[?(@.key == 'gender')].explanation").value("The biological sex of the individual human"))
                     .andExpect(jsonPath("$.relations.length()").value(2));
         }
@@ -105,8 +105,8 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canAddAttributeToExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.getAttributes().add(
                     attribute()
@@ -124,7 +124,7 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new attribute and old relations
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(2))
+                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(3))
                     .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes[?(@.key == 'isFictional')].type").value("ENUM"))
                     .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes[?(@.key == 'isFictional')].allowedValues.length()").value(3))
                     .andExpect(jsonPath("$.relations.length()").value(2));
@@ -133,8 +133,8 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void cannotAddAttributeWithAlreadyExistingToToExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.getAttributes().add(
                     attribute()
@@ -155,14 +155,14 @@ public class AdminApiTypeUpdateIntegrationTest {
                     .andExpect(jsonPath("$.errors[0].field").value("attributes[0].key"))
                     .andExpect(jsonPath("$.errors[0].constraint").value("Unique"))
                     .andExpect(jsonPath("$.errors[0].message").value("org.chronos.schema.error.duplicate-key"))
-                    .andExpect(jsonPath("$.errors[1].field").value("attributes[1].key"))
+                    .andExpect(jsonPath("$.errors[1].field").value("attributes[2].key"))
                     .andExpect(jsonPath("$.errors[1].constraint").value("Unique"))
                     .andExpect(jsonPath("$.errors[1].message").value("org.chronos.schema.error.duplicate-key"))
                     .andExpect(jsonPath("$.errors[0].arguments").doesNotExist());
 
             // After: Exists, with old attributes and old relations
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(1))
+                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(2))
                     .andExpect(jsonPath("$.relations.length()").value(2));
         }
 
@@ -170,8 +170,8 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canRemoveAttributeFromExistingType() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getAttributes().size(), is(1));
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getAttributes().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             type.getAttributes().remove(0);
 
@@ -181,9 +181,9 @@ public class AdminApiTypeUpdateIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk());
 
-            // After: Exists, without attributes and old relations
+            // After: Exists, with last attribute and old relations
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").doesNotHaveJsonPath())
+                    .andExpect(jsonPath("$.types.elements[?(@.key == 'Person')].attributes.length()").value(1))
                     .andExpect(jsonPath("$.relations.length()").value(2));
         }
     }
@@ -197,7 +197,7 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canUpdateSimpleFieldInExistingRelation() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation =
                     type.getRelations().stream()
@@ -222,7 +222,7 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canRemoveRelation() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation =
                     type.getRelations().stream()
@@ -237,18 +237,18 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, without removed relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(1))
+                    .andExpect(jsonPath("$.relations.elements.length()").value(2))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')]").doesNotExist());
         }
 
         @Test
         void canAddRelation() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation =
                     relation()
-                            .withKey("CHILD_OF")
+                            .withKey("PARENT_OF")
                             .withTarget(type)
                             .withAttribute(relationAttribute()
                                     .withKey("type")
@@ -267,16 +267,16 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(3))
-                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'CHILD_OF')].attributes.length()").value(1))
-                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'CHILD_OF')].attributes[0].key").value("type"))
-                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'CHILD_OF')].attributes[0].allowedValues[?(@ == 'adopted')]").exists());
+                    .andExpect(jsonPath("$.relations.elements.length()").value(4))
+                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'PARENT_OF')].attributes.length()").value(1))
+                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'PARENT_OF')].attributes[0].key").value("type"))
+                    .andExpect(jsonPath("$.relations.elements[?(@.key == 'PARENT_OF')].attributes[0].allowedValues[?(@ == 'adopted')]").exists());
         }
 
         @Test
         void canAddRelationAttribute() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation = type.getRelations().stream().filter(rel -> rel.getKey().equals("RULED")).findFirst().get();
             relation.getAttributes().add(
@@ -294,7 +294,7 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(2))
+                    .andExpect(jsonPath("$.relations.elements.length()").value(3))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RULED')].attributes.length()").value(2))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RULED')].attributes[?(@.key == 'legitimacy')].type").value("STRING"));
         }
@@ -302,7 +302,7 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void canRemoveRelationAttribute() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation = type.getRelations().stream().filter(rel -> rel.getKey().equals("RULED")).findFirst().get();
             relation.getAttributes().removeIf(attr -> attr.getKey().equals("status"));
@@ -315,14 +315,14 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(2))
+                    .andExpect(jsonPath("$.relations.elements.length()").value(3))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RULED')].attributes.length()").value(0));
         }
 
         @Test
         void cannotAddRelationWithDuplicateKey() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation =
                     relation()
@@ -351,7 +351,7 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(2))
+                    .andExpect(jsonPath("$.relations.elements.length()").value(3))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes.length()").value(1))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes[0].key").value("status"))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes[0].allowedValues[?(@ == 'cohabitation')]").exists());
@@ -360,7 +360,7 @@ public class AdminApiTypeUpdateIntegrationTest {
         @Test
         void cannotAddRelationAttributeWithDuplicateKey() throws Exception {
             TypePO type = loadType("Person");
-            assertThat(type.getRelations().size(), is(2));
+            assertThat(type.getRelations().size(), is(3));
 
             RelationPO relation = type.getRelations().stream().filter(rel -> rel.getKey().equals("RELATIONSHIP_WITH")).findFirst().get();
             relation.getAttributes().add(
@@ -388,7 +388,7 @@ public class AdminApiTypeUpdateIntegrationTest {
 
             // After: Exists, with new relation
             getType("Person").andExpect(status().isOk())
-                    .andExpect(jsonPath("$.relations.elements.length()").value(2))
+                    .andExpect(jsonPath("$.relations.elements.length()").value(3))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes.length()").value(1))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes[0].key").value("status"))
                     .andExpect(jsonPath("$.relations.elements[?(@.key == 'RELATIONSHIP_WITH')].attributes[0].allowedValues[?(@ == 'cohabitation')]").exists());

--- a/dev/requests/data.http
+++ b/dev/requests/data.http
@@ -32,7 +32,7 @@ GET http://localhost:8010/api/data?sortBy=from&pageSize=5&from:gt=0032-04-28
 ### 
 
 # Filter example: First random Entry with wikipedia QID
-GET http://localhost:8010/api/data?qid:not=null&sortBy=random
+GET http://localhost:8010/api/data?wikiqid:not=null&sortBy=random
 
 
 ### ADMIN
@@ -40,7 +40,7 @@ GET http://localhost:8010/api/data?qid:not=null&sortBy=random
 ###
 
 
-GET http://localhost:8010/api/data/admin
+POST http://localhost:8010/api/data/admin
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJsb2NhbGhvc3QiLCJzdWIiOiJyb2xlLXVzZXIiLCJyZXNvdXJjZV9hY2Nlc3MiOnsiY2hyb25vcy1hZG1pbi11aSI6eyJyb2xlcyI6WyJjaHJvbm9zX2NsaWVudF9zY2hlbWEtYWRtaW4iXX19LCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJyb2xlLXVzZXIiLCJleHAiOjQ5MjM0OTg4NzYsImlhdCI6MTc2OTg5ODg3Nn0.U1BLkDG3rrLLb-3sSY8kuWs4tk0o6TU54XJmRgRCY-GVl8VSCmJscJsane-xyJmAq9Yrn8kkeH6l23C3c7ewyq4bV8bX_lIGlQuCh2SnKUzpxiLt7mC4X4I3_A7fXSIqMnHWPveUYM33HRn5NTT56ycGHH11ER9NtchlXmh5SN6ApSrNiIP22RscnJMB2bu9LbqYvjmKHBFd8XZPFxcD-VsGdKADb9kB7WlobFvYxuogUD5i4yf1xzgDPCkuiecw5JfVuSu32UoaSNuvEf6Z0HyXPAXxp5G2uJT2AuiGaa6j4XAnARpzn0YGO_5ZE9fp7F-P-6VbvEt3-nbSiklbEQ
 


### PR DESCRIPTION
Minor adjustments:

- Add test schema type that contains all constellations of types and configs
- Align test data with entry structure
- Make schema type and type attribute form more concise and interactive with selected type and properties (e.g. Allowed Values only for ENUM, pattern for Strings)
- Allow to display also backend errors
- Save and save & return buttons (but in one button group)
- Wrap info icon & tool tip into component (see https://github.com/radyak/chronos/issues/4)
- Check Cypher injection security
- Align Entry class fields with Schema Type